### PR TITLE
Manual receiver deregistration

### DIFF
--- a/include/tos_container.h
+++ b/include/tos_container.h
@@ -1,0 +1,24 @@
+#ifndef TOS_CONTAINER_H_
+#define TOS_CONTAINER_H_
+
+/**
+ * Initialize the container radio layer. Do this first.
+ *
+ * @param A functional mist-comm layer.
+ * @return 0 for success.
+ */
+int container_am_radio_init(comms_layer_t* cl);
+
+/**
+ * Initialize and boot the container.
+ * @param tos_node_id The TinyOS node ID - TOS_NODE_ID.
+ */
+void container_boot(uint16_t tos_node_id);
+
+/**
+ * Poll the container.
+ * @return True, if more tasks in queue.
+ */
+bool container_run();
+
+#endif//TOS_CONTAINER_H_

--- a/include/tos_container.h
+++ b/include/tos_container.h
@@ -10,6 +10,17 @@
 int container_am_radio_init(comms_layer_t* cl);
 
 /**
+ * Connect container radio to real radio, done automatically if radio
+ * started by container application.
+ */
+void container_am_radio_connect();
+
+/**
+ * Disconnect container radio from real radio, not done automatically.
+ */
+void container_am_radio_disconnect();
+
+/**
  * Initialize and boot the container.
  * @param tos_node_id The TinyOS node ID - TOS_NODE_ID.
  */

--- a/tos/platforms/container/ActiveMessageC.nc
+++ b/tos/platforms/container/ActiveMessageC.nc
@@ -20,7 +20,7 @@ configuration ActiveMessageC {
 
 		interface PacketField<uint8_t> as PacketLinkQuality;
 		//interface PacketField<uint8_t> as PacketTransmitPower;
-		interface PacketField<uint8_t> as PacketRSSI;
+		interface PacketField<int8_t> as PacketRSSI;
 		//interface LinkPacketMetadata;
 
 		interface LocalTime<TRadio> as LocalTimeRadio;

--- a/tos/platforms/container/ActiveMessageC.nc
+++ b/tos/platforms/container/ActiveMessageC.nc
@@ -72,10 +72,10 @@ implementation {
 	TimeSyncAMSendMilli = ActiveMessageP.TimeSyncAMSendMilli;
 	TimeSyncPacketMilli = ActiveMessageP.TimeSyncPacketMilli;
 
-	components new QueueC(message_t*, 3) as RxQueueC;
+	components new QueueC(message_t*, 5) as RxQueueC;
 	ActiveMessageP.RxQueue -> RxQueueC;
 
-	components new PoolC(message_t, 3) as RxPoolC;
+	components new PoolC(message_t, 5) as RxPoolC;
 	ActiveMessageP.RxPool -> RxPoolC;
 
 	components LocalTimeMilliC;

--- a/tos/platforms/container/ActiveMessageC.nc
+++ b/tos/platforms/container/ActiveMessageC.nc
@@ -72,6 +72,12 @@ implementation {
 	TimeSyncAMSendMilli = ActiveMessageP.TimeSyncAMSendMilli;
 	TimeSyncPacketMilli = ActiveMessageP.TimeSyncPacketMilli;
 
+	components new QueueC(message_t*, 3) as RxQueueC;
+	ActiveMessageP.RxQueue -> RxQueueC;
+
+	components new PoolC(message_t, 3) as RxPoolC;
+	ActiveMessageP.RxPool -> RxPoolC;
+
 	components LocalTimeMilliC;
 	ActiveMessageP.LocalTimeMilli -> LocalTimeMilliC;
 

--- a/tos/platforms/container/ActiveMessageC.nc
+++ b/tos/platforms/container/ActiveMessageC.nc
@@ -72,10 +72,10 @@ implementation {
 	TimeSyncAMSendMilli = ActiveMessageP.TimeSyncAMSendMilli;
 	TimeSyncPacketMilli = ActiveMessageP.TimeSyncPacketMilli;
 
-	components new QueueC(message_t*, 5) as RxQueueC;
+	components new QueueC(message_t*, 10) as RxQueueC;
 	ActiveMessageP.RxQueue -> RxQueueC;
 
-	components new PoolC(message_t, 5) as RxPoolC;
+	components new PoolC(message_t, 10) as RxPoolC;
 	ActiveMessageP.RxPool -> RxPoolC;
 
 	components LocalTimeMilliC;

--- a/tos/platforms/container/ActiveMessageP.nc
+++ b/tos/platforms/container/ActiveMessageP.nc
@@ -201,9 +201,12 @@ implementation {
 				}
 				else warn1("rcv p:%d q:%d", call RxPool.size(), call RxQueue.size());
 			}
-			else debug1("rcv off");
+			else {
+
+				debug1("rcv off");
+				notify_resume_container();
+			}
 		}
-		notify_resume_container();
 	}
 
 	task void startDone() {
@@ -253,6 +256,7 @@ implementation {
 			m_control_error = TRUE;
 		}
 		post startDone();
+		notify_resume_container();
 	}
 
 	void radio_stop_done(comms_layer_t* comms, comms_status_t status, void* user) {
@@ -263,6 +267,7 @@ implementation {
 			m_control_error = TRUE;
 		}
 		post stopDone();
+		notify_resume_container();
 	}
 
 	// SplitControl interface

--- a/tos/platforms/container/ActiveMessageP.nc
+++ b/tos/platforms/container/ActiveMessageP.nc
@@ -58,6 +58,8 @@ implementation {
 
 	comms_layer_t* m_radio = NULL;
 
+	bool m_radio_set_up = FALSE;
+
 	int container_am_radio_init(comms_layer_t* cl) @C() @spontaneous() {
 		m_radio = cl;
 		return 0;
@@ -153,25 +155,28 @@ implementation {
 				}
 				else err1("rcv cpy");
 			}
-			else warn("rcv bsy");
+			else warn1("rcv bsy");
 		}
-		else warn("rcv off");
+		else warn1("rcv off");
 	}
 
 	task void startDone() {
-		uint8_t i;
-		for(i=0;i<sizeof(rcvids);i++) {
-			comms_register_recv(m_radio, &m_receivers[i], commsReceive, NULL, rcvids[i]);
+		if(m_radio_set_up == FALSE) {
+			uint8_t i;
+			for(i=0;i<sizeof(rcvids);i++) {
+				comms_register_recv(m_radio, &m_receivers[i], commsReceive, NULL, rcvids[i]);
+			}
+			m_radio_set_up = TRUE;
 		}
 		signal SplitControl.startDone(SUCCESS);
 		m_state = ST_RUNNING; // Will not let anything be done from the startDone event
 	}
 
 	task void stopDone() {
-		uint8_t i;
-		for(i=0;i<sizeof(rcvids);i++) {
-			comms_deregister_recv(m_radio, &m_receivers[i]);
-		}
+		//uint8_t i;
+		//for(i=0;i<sizeof(rcvids);i++) {
+		//	comms_deregister_recv(m_radio, &m_receivers[i]);
+		//}
 		signal SplitControl.stopDone(SUCCESS);
 		m_state = ST_OFF;
 	}

--- a/tos/platforms/container/ActiveMessageP.nc
+++ b/tos/platforms/container/ActiveMessageP.nc
@@ -139,6 +139,7 @@ implementation {
 				if(m_state != ST_RUNNING) {
 					debug1("rcv off q:%d", call RxQueue.size());
 					call RxPool.put(msg);
+					msg = NULL;
 				}
 				else {
 					break; // process the message

--- a/tos/platforms/container/ActiveMessageP.nc
+++ b/tos/platforms/container/ActiveMessageP.nc
@@ -246,7 +246,7 @@ implementation {
 
 			if(tosToComms(&s_commsmsg, msg) == SUCCESS) {
 				comms_error_t err = comms_send(m_radio, &s_commsmsg, &commsSendDone, msg);
-				debug1("send(%p)=%d\n", &s_commsmsg, err);
+				debug1("send(%p)=%d", &s_commsmsg, err);
 				if(err == COMMS_SUCCESS) {
 					s_tosmsg = msg;
 					return SUCCESS;
@@ -515,7 +515,7 @@ implementation {
 
 			if(tosToComms(&s_tr_commsmsg, msg) == SUCCESS) {
 				comms_error_t err = comms_send(m_radio, &s_tr_commsmsg, &commsTimestampRadioSendDone, msg);
-				debug1("send(%p)=%d\n", &s_tr_commsmsg, err);
+				debug1("send(%p)=%d", &s_tr_commsmsg, err);
 				if(err == COMMS_SUCCESS) {
 					s_tr_tosmsg = msg;
 					return SUCCESS;
@@ -579,7 +579,7 @@ implementation {
 
 			if(tosToComms(&s_tm_commsmsg, msg) == SUCCESS) {
 				comms_error_t err = comms_send(m_radio, &s_tm_commsmsg, &commsTimestampMilliSendDone, msg);
-				debug1("send(%p)=%d\n", &s_tm_commsmsg, err);
+				debug1("send(%p)=%d", &s_tm_commsmsg, err);
 				if(err == COMMS_SUCCESS) {
 					s_tm_tosmsg = msg;
 					return SUCCESS;

--- a/tos/platforms/container/ActiveMessageP.nc
+++ b/tos/platforms/container/ActiveMessageP.nc
@@ -227,7 +227,6 @@ implementation {
 	}
 
 	void commsSendDone(comms_layer_t* comms, comms_msg_t* msg, comms_error_t result, void* user) {
-		s_tosmsg = user;
 		if(result == COMMS_SUCCESS) {
 			s_result = SUCCESS;
 		}
@@ -249,6 +248,7 @@ implementation {
 				comms_error_t err = comms_send(m_radio, &s_commsmsg, &commsSendDone, msg);
 				debug1("send(%p)=%d\n", &s_commsmsg, err);
 				if(err == COMMS_SUCCESS) {
+					s_tosmsg = msg;
 					return SUCCESS;
 				}
 				return FAIL;

--- a/tos/platforms/container/ActiveMessageP.nc
+++ b/tos/platforms/container/ActiveMessageP.nc
@@ -87,6 +87,9 @@ implementation {
 		}
 
 		comms_set_ack_required(m_radio, cmsg, ((radio_metadata_t*)(msg->metadata))->ack_requested);
+		comms_set_retries(m_radio, cmsg, ((radio_metadata_t*)(msg->metadata))->retries);
+		comms_set_timeout(m_radio, cmsg, ((radio_metadata_t*)(msg->metadata))->timeout);
+		comms_set_retries_used(m_radio, cmsg, 0);
 
 		payload = comms_get_payload(m_radio, cmsg, len);
 		if(payload == NULL) {
@@ -428,13 +431,20 @@ implementation {
 	// PacketLink interface
 	command void PacketLink.setRetries(message_t *msg, uint16_t maxRetries) {
 		((radio_metadata_t*)(msg->metadata))->ack_requested = TRUE;
+		((radio_metadata_t*)(msg->metadata))->retries = (uint8_t)maxRetries;
 	}
 
-	command void PacketLink.setRetryDelay(message_t *msg, uint16_t retryDelay) { }
+	command void PacketLink.setRetryDelay(message_t *msg, uint16_t retryDelay) {
+		((radio_metadata_t*)(msg->metadata))->timeout = retryDelay;
+	}
 
-  	command uint16_t PacketLink.getRetries(message_t *msg) { return 0; }
+  	command uint16_t PacketLink.getRetries(message_t *msg) { 
+  		return ((radio_metadata_t*)(msg->metadata))->retries;
+  	}
 
-	command uint16_t PacketLink.getRetryDelay(message_t *msg) { return 0; }
+	command uint16_t PacketLink.getRetryDelay(message_t *msg) { 
+		return ((radio_metadata_t*)(msg->metadata))->timeout;
+	}
 
   	command bool PacketLink.wasDelivered(message_t *msg) {
   		return ((radio_metadata_t*)(msg->metadata))->ack_received;

--- a/tos/platforms/container/ActiveMessageP.nc
+++ b/tos/platforms/container/ActiveMessageP.nc
@@ -22,7 +22,7 @@ module ActiveMessageP {
 
 		interface PacketField<uint8_t> as PacketLinkQuality;
 		//interface PacketField<uint8_t> as PacketTransmitPower;
-		interface PacketField<uint8_t> as PacketRSSI;
+		interface PacketField<int8_t> as PacketRSSI;
 		//interface LinkPacketMetadata;
 
 		interface LocalTime<TRadio> as LocalTimeRadio;
@@ -119,7 +119,8 @@ implementation {
 			((radio_metadata_t*)(msg->metadata))->event_time_valid = comms_event_time_valid(m_radio, cmsg);
 
 			call PacketLinkQuality.set(msg, comms_get_lqi(m_radio, cmsg));
-			call PacketRSSI.set(msg, (90+comms_get_rssi(m_radio, cmsg))/3 + 1); // RFR2 RSSI 0-28 units
+			call PacketRSSI.set(msg, comms_get_rssi(m_radio, cmsg));
+
 
 			payload = call Packet.getPayload(msg, len);
 			if(payload == NULL) {
@@ -160,13 +161,13 @@ implementation {
 			uint8_t length = call Packet.payloadLength(msg);
 
 			if(call TimeSyncPacketMilli.isValid(msg)) {
-				debug1("rcv %02"PRIX8" %04"PRIX16" r:%"PRIu8" age=%"PRIi32,
+				debug1("rcv %02"PRIX8" %04"PRIX16" r:%"PRIi8" age=%"PRIi32,
 					   call AMPacket.type(msg), call AMPacket.source(msg),
                        call PacketRSSI.get(msg),
 				       call LocalTimeMilli.get() - call TimeSyncPacketMilli.eventTime(msg));
 			}
 			else {
-				debug1("rcv %02"PRIX8" %04"PRIX16" r:%"PRIu8,
+				debug1("rcv %02"PRIX8" %04"PRIX16" r:%"PRIi8,
 					   call AMPacket.type(msg), call AMPacket.source(msg),
 					   call PacketRSSI.get(msg));
 			}
@@ -521,13 +522,13 @@ implementation {
 	async command bool PacketRSSI.isSet(message_t* msg) {
 		return ((radio_metadata_t*)(msg->metadata))->rssi_set;
 	}
-	async command uint8_t PacketRSSI.get(message_t* msg) {
+	async command int8_t PacketRSSI.get(message_t* msg) {
 		return ((radio_metadata_t*)(msg->metadata))->rssi;
 	}
 	async command void PacketRSSI.clear(message_t* msg) {
 		((radio_metadata_t*)(msg->metadata))->rssi_set = FALSE;
 	}
-	async command void PacketRSSI.set(message_t* msg, uint8_t value) {
+	async command void PacketRSSI.set(message_t* msg, int8_t value) {
 		((radio_metadata_t*)(msg->metadata))->rssi_set = TRUE;
 		((radio_metadata_t*)(msg->metadata))->rssi = value;
 	}

--- a/tos/platforms/container/ActiveMessageP.nc
+++ b/tos/platforms/container/ActiveMessageP.nc
@@ -289,7 +289,7 @@ implementation {
 			return EALREADY;
 		}
 		if(m_state == ST_RUNNING) {
-			comms_error_t rslt = comms_start(m_radio, radio_stop_done, NULL);
+			comms_error_t rslt = comms_stop(m_radio, radio_stop_done, NULL);
 			if(rslt == COMMS_SUCCESS) {
 				m_state = ST_STOPPING;
 				return SUCCESS;

--- a/tos/platforms/container/ActiveMessageP.nc
+++ b/tos/platforms/container/ActiveMessageP.nc
@@ -133,16 +133,18 @@ implementation {
 	default event message_t* Receive.receive[uint8_t id](message_t* msg, void* payload, uint8_t length) { return msg; }
 
 	task void receivedMessage() {
-		uint8_t length = call Packet.payloadLength(r_tosmsg);
+		if(m_state == ST_RUNNING) {
+			uint8_t length = call Packet.payloadLength(r_tosmsg);
 
-		if(call TimeSyncPacketMilli.isValid(r_tosmsg)) {
-			debug1("rcv %02X %04X age=%"PRIi32, call AMPacket.type(r_tosmsg), call AMPacket.source(r_tosmsg), call LocalTimeMilli.get() - call TimeSyncPacketMilli.eventTime(r_tosmsg));
-		}
-		else {
-			debug1("rcv %02X %04X", call AMPacket.type(r_tosmsg), call AMPacket.source(r_tosmsg));
-		}
+			if(call TimeSyncPacketMilli.isValid(r_tosmsg)) {
+				debug1("rcv %02X %04X age=%"PRIi32, call AMPacket.type(r_tosmsg), call AMPacket.source(r_tosmsg), call LocalTimeMilli.get() - call TimeSyncPacketMilli.eventTime(r_tosmsg));
+			}
+			else {
+				debug1("rcv %02X %04X", call AMPacket.type(r_tosmsg), call AMPacket.source(r_tosmsg));
+			}
 
-		r_tosmsg = signal Receive.receive[call AMPacket.type(r_tosmsg)](r_tosmsg, call Packet.getPayload(r_tosmsg, length), length);
+			r_tosmsg = signal Receive.receive[call AMPacket.type(r_tosmsg)](r_tosmsg, call Packet.getPayload(r_tosmsg, length), length);
+		}
 		r_busy = FALSE;
 	}
 
@@ -177,8 +179,8 @@ implementation {
 		//for(i=0;i<sizeof(rcvids);i++) {
 		//	comms_deregister_recv(m_radio, &m_receivers[i]);
 		//}
-		signal SplitControl.stopDone(SUCCESS);
 		m_state = ST_OFF;
+		signal SplitControl.stopDone(SUCCESS);
 	}
 
 	// SplitControl interface

--- a/tos/platforms/container/ActiveMessageP.nc
+++ b/tos/platforms/container/ActiveMessageP.nc
@@ -290,6 +290,9 @@ implementation {
 	}
 
 	command error_t SplitControl.stop() {
+		if(m_radio == NULL) {
+			return ENOMEM;
+		}
 		if(m_state == ST_OFF) {
 			return EALREADY;
 		}
@@ -299,6 +302,7 @@ implementation {
 				m_state = ST_STOPPING;
 				return SUCCESS;
 			}
+			return FAIL;
 		}
 		return EBUSY;
 	}

--- a/tos/platforms/container/ActiveMessageP.nc
+++ b/tos/platforms/container/ActiveMessageP.nc
@@ -56,7 +56,7 @@ implementation {
 
 	uint8_t m_state = ST_OFF;
 
-	const uint8_t rcvids[] = {0x3D, 0xB0, 0xB1, 0xB2, 0xB7}; // TODO the list should come from build process
+	const uint8_t rcvids[] = {0xB0, 0xB1, 0xB2, 0xB3, 0xB4, 0xB5, 0xB7}; // TODO the list should come from build process
 	comms_receiver_t m_receivers[sizeof(rcvids)];
 
 	comms_layer_t* m_radio = NULL;

--- a/tos/platforms/container/AlarmCounterMilli32P.nc
+++ b/tos/platforms/container/AlarmCounterMilli32P.nc
@@ -12,6 +12,7 @@ implementation {
 	#include "log.h"
 
 	extern uint32_t osCounterMilliGet() @C();
+	extern void notify_resume_container() @C();
 
 	enum {
 		ALARM_COUNT = uniqueCount("AlarmMilli32C")
@@ -48,6 +49,7 @@ implementation {
 			}
 			signal Alarm.fired[tmr]();
 		}
+		notify_resume_container();
 	}
 
 	async command void Alarm.start[uint8_t tmr](uint32_t dt) {

--- a/tos/platforms/container/AlarmCounterMilli32P.nc
+++ b/tos/platforms/container/AlarmCounterMilli32P.nc
@@ -11,7 +11,7 @@ implementation {
 	#define __LOG_LEVEL__ ( LOG_LEVEL_AlarmCounterMilli32P & BASE_LOG_LEVEL )
 	#include "log.h"
 
-	extern uint32_t osCounterMilliGet() @C();
+	extern uint32_t osCounterGetMilli() @C();
 	extern void notify_resume_container() @C();
 
 	enum {
@@ -135,7 +135,7 @@ implementation {
 	// -----
 
 	async command uint32_t Counter.get() {
-		return osCounterMilliGet();
+		return osCounterGetMilli();
 	}
 
 	async command bool Counter.isOverflowPending() {

--- a/tos/platforms/container/AlarmCounterMilli32P.nc
+++ b/tos/platforms/container/AlarmCounterMilli32P.nc
@@ -41,11 +41,13 @@ implementation {
 	// -----
 
 	void timer_callback(void* argument) @C() {
-		uint8_t tmr = (argument - (void*)timers)/sizeof(void*);
-		if(tmr >= ALARM_COUNT) {
-			err1("tmr %"PRIu8, tmr);
+		atomic {
+			uint8_t tmr = (argument - (void*)timers)/sizeof(void*);
+			if(tmr >= ALARM_COUNT) {
+				err1("tmr %"PRIu8, tmr);
+			}
+			signal Alarm.fired[tmr]();
 		}
-		signal Alarm.fired[tmr]();
 	}
 
 	async command void Alarm.start[uint8_t tmr](uint32_t dt) {

--- a/tos/platforms/container/AlarmCounterMilli32P.nc
+++ b/tos/platforms/container/AlarmCounterMilli32P.nc
@@ -52,6 +52,10 @@ implementation {
 			debug1("start[%d] 0x%x %"PRIu32"+%"PRIu32, tmr, timers[tmr], ta - dt, dt);
 		#endif
 
+		if(dt == 0) { // TODO special handling? use a task and call it from there?
+			dt = 1; // osTimerStart does not accept 0
+		}
+
 		atomic {
 			alarm[tmr] = ta;
 			osTimerStart(timers[tmr], dt);
@@ -59,7 +63,7 @@ implementation {
 	}
 
 	async command void Alarm.stop[uint8_t tmr]() {
-		if (osTimerIsRunning(timers[tmr])) {
+		if(osTimerIsRunning(timers[tmr])) {
 			
 			#ifdef ACM_DEBUG
 				debug1("stp[%d] 0x%x", tmr, timers[tmr]);
@@ -81,8 +85,12 @@ implementation {
 		#endif
 
 		atomic {
+			uint32_t tdt = ta - call Counter.get();
+			if(tdt == 0) { // TODO special handling
+				tdt = 1;
+			}
 			alarm[tmr] = ta;
-			osTimerStart(timers[tmr], ta - call Counter.get());
+			osTimerStart(timers[tmr], tdt);
 		}
 	}
 
@@ -117,3 +125,4 @@ implementation {
 	// async event void Counter.overflow();
 
 }
+

--- a/tos/platforms/container/RealMainP.nc
+++ b/tos/platforms/container/RealMainP.nc
@@ -1,4 +1,9 @@
 // Container RealMainP
+
+#include "cmsis_os2.h"
+
+osMutexId_t atomic_mutex;
+
 module RealMainP @safe() {
 	provides interface Boot;
 	uses {
@@ -12,6 +17,9 @@ implementation {
 	#warning "Container RealMainP"
 
 	void container_boot(uint16_t tos_node_id) @C() @spontaneous() {
+		osMutexAttr_t mutex_param = {.attr_bits = osMutexRecursive};
+		atomic_mutex = osMutexNew(&mutex_param);
+
 		atomic {
 			TOS_NODE_ID = tos_node_id;
 
@@ -33,6 +41,16 @@ implementation {
 
 	bool container_run() @C() @spontaneous() {
 		return call Scheduler.runNextTask();
+	}
+
+	void container_destroy() @C() @spontaneous() {
+		// TODO deinitialize platform
+		// Probably quite difficult to actually cleanly do, but;
+		//    timers
+		//    radio
+		//    let the task queue empty or kill the scheduler somehow?
+		//    ... anything else?
+		// delete the atomic_mutex
 	}
 
 	default command error_t PlatformInit.init() { return SUCCESS; }

--- a/tos/platforms/container/hardware.h
+++ b/tos/platforms/container/hardware.h
@@ -1,27 +1,32 @@
 #ifndef HARDWARE_H
 #define HARDWARE_H
 
+#include "cmsis_os2.h"
+
 typedef uint8_t __nesc_atomic_t;
 __nesc_atomic_t __nesc_atomic_start(void);
 void __nesc_atomic_end(__nesc_atomic_t original);
 
 #ifndef NESC_BUILD_BINARY
 
+extern osMutexId_t atomic_mutex;
+
 inline __nesc_atomic_t __nesc_atomic_start(void) @spontaneous() @safe() {
-	// TODO
+	// Acquire a recursive mutex initialized in container_boot
+	while(osMutexAcquire(atomic_mutex, 1000) != osOK);
 	return 0;
 }
 
-inline void __nesc_atomic_end(__nesc_atomic_t original_SREG) @spontaneous() @safe() {
-	// TODO
+inline void __nesc_atomic_end(__nesc_atomic_t original) @spontaneous() @safe() {
+	osMutexRelease(atomic_mutex);
 }
 
 inline void __nesc_enable_interrupt() @safe() {
-	// TODO
+	// TinyOS is not allowed to actually disable interrupts
 }
 
 inline void __nesc_disable_interrupt() @safe() {
-	// TODO
+	// TinyOS is not allowed to actually disable interrupts
 }
 
 // TODO wdt stuff needs cleanup

--- a/tos/platforms/container/platform_message.h
+++ b/tos/platforms/container/platform_message.h
@@ -27,6 +27,9 @@ typedef struct radio_metadata {
 
 	bool ack_requested;
 	bool ack_received;
+
+	uint16_t retries;
+	uint32_t timeout;
 } radio_metadata_t;
 
 typedef union message_metadata {

--- a/tos/platforms/container/platform_message.h
+++ b/tos/platforms/container/platform_message.h
@@ -22,7 +22,7 @@ typedef struct radio_metadata {
 	uint8_t lqi;
 	bool lqi_set;
 
-	uint8_t rssi;
+	int8_t rssi;
 	bool rssi_set;
 
 	bool ack_requested;


### PR DESCRIPTION
Originally the container would deregister all receivers when radio was stopped. This turned out to be a bad idea, mostly because of sync bugs, but is perhaps a pointless activity when we know it will get started soon anyway and all those registrations are important. However there are cases (like the gateway) where we do need to take the receivers down and an option has been added for this. Re-registration is done automatically, so no changes should be needed elsewhere.

Additionally the millisecond counter name was changed to be more aligned with CMSIS names - osCounterGetMilli. So this needs to be changed, however a function and header to include is now available in https://github.com/thinnect/cmsis-ext (dev branch at the moment).